### PR TITLE
Update for newer versions of Awesome

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,7 @@
 
 -- standard libraries
 local spawn = require("awful.util").spawn or require("awful.spawn")
+---@diagnostic disable-next-line:undefined-global
 local gtimer = timer or require("gears.timer")
 
 -- variables

--- a/init.lua
+++ b/init.lua
@@ -5,7 +5,8 @@
 --
 
 -- standard libraries
-local awful = require("awful")
+local spawn = require("awful.util").spawn or require("awful.spawn")
+local gtimer = timer or require("gears.timer")
 
 -- variables
 local redshift = {}
@@ -13,16 +14,16 @@ redshift.redshift = "/usr/bin/redshift"    -- binary path
 redshift.method   = "randr"                -- randr or vidmode
 redshift.options  = ""                     -- additional redshift command options
 redshift.state    = 1                      -- 1 for screen dimming, 0 for none
-redshift.timer    = timer({ timeout = 60 })
+redshift.timer    = gtimer({ timeout = 60 })
 
 -- functions
 function redshift.dim()
     if redshift.method == "randr" then
-        awful.util.spawn(redshift.redshift .. " -m randr -o " .. redshift.options)
+        spawn(redshift.redshift .. " -m randr -o " .. redshift.options)
     elseif redshift.method == "vidmode" then
         local screens = screen.count()
         for i = 0, screens - 1 do
-            awful.util.spawn(redshift.redshift .. " -m vidmode:screen=" .. i ..
+            spawn(redshift.redshift .. " -m vidmode:screen=" .. i ..
                              " -o " .. redshift.options)
         end
     end
@@ -33,11 +34,11 @@ end
 redshift.timer:connect_signal("timeout", redshift.dim)
 function redshift.undim()
     if redshift.method == "randr" then
-        awful.util.spawn(redshift.redshift .. " -m randr -x " .. redshift.options)
+        spawn(redshift.redshift .. " -m randr -x " .. redshift.options)
     elseif redshift.method == "vidmode" then
         local screens = screen.count()
         for i = 0, screens - 1 do
-            awful.util.spawn(redshift.redshift .. " -m vidmode:screen=" .. i ..
+            spawn(redshift.redshift .. " -m vidmode:screen=" .. i ..
                              " -x " .. redshift.options)
         end
     end

--- a/init.lua
+++ b/init.lua
@@ -6,8 +6,10 @@
 
 -- standard libraries
 local spawn = require("awful.util").spawn or require("awful.spawn")
+
+local has_gears_timer = pcall(require, "gears.timer")
 ---@diagnostic disable-next-line:undefined-global
-local gtimer = timer or require("gears.timer")
+local gtimer = has_gears_timer and require("gears.timer") or timer
 
 -- variables
 local redshift = {}


### PR DESCRIPTION
as `timer` and `awful.util.spawn` have been deprecated, I figured it would be a good idea to future-proof the codebase as much as possible.